### PR TITLE
Refactor the versions in samplesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ The goal is to prevent unauthorized access of potentially identifying informatio
 
 Requirements:
 As described [here](https://github.com/Ferlab-Ste-Justine/smrtlink-scripts/blob/main/python/README.md#running-the-updateurlpy-script), this script requires environment variables for key ID and access, both for the s3 bucket and the GeneYX account. 
-A second requirement is to include a file as argument containing the sample names and their path version on GeneYX, separated by comma. A version of "1" corresponds to samples using the format "{sample_name}.GRCh38.deepvariant.phased.vcf.gz" on GeneYX, and the version "2" corresponds to: "{sample_name}.GRCh38.small_variants.phased.vcf.gz".
+A second requirement is to include a file as argument containing the sample names and their vcf Name on GeneYX, separated by comma. For joint calls, the vcf name is preceded by the family ID and the role of the sample, separated by slash ('/').
 The input file will use a format like the following:
 
 ```
-sample_1,1
-sample_2,1
-sample_3,2
+sample_1,sample_1_vcf.vcf.gz
+sample_2,familyID/father/father_familyID.vcf.gz
 ```
 The script will print the combined URL of BAM and methylation files for all samples, along with a code of "success" or "{sample_name} failed to send". 
 Once all the files are processed, a list of the samples that failed to send is printed. 

--- a/python/scripts/updateURL.py
+++ b/python/scripts/updateURL.py
@@ -62,24 +62,17 @@ def main():
         bucket_name = PACBIO_DATA_BUCKET
 
         #2 possibilities for version:
-        #- Version is just an integer (1 or 2) which is just the format of the VCF
-        #- Version contains the trioName/Role (ex p001/Proband, p022/Father)
+        #- Version is the name of the vcf directly
+        #- Version follows trioName/Role/vcfName (ex p001/Proband/XXX.vcf, p022/Father/YYY.vcf)
         #   which is a different VCF and path format for joint calls
-        if version=="1":
-            vcfName=sample_name+".GRCh38.deepvariant.phased.vcf.gz"
-            base_folder = f"S3-Storage/{sample_name}/"
-        elif version=="2":
-            vcfName=sample_name+".GRCh38.small_variants.phased.vcf.gz"
-            base_folder = f"S3-Storage/{sample_name}/"
-
-        elif "/" in version and ("proband" in version or "mother" in version or "father" in version):
+        if "/" in version and ("proband" in version or "mother" in version or "father" in version):
             trioName = version.split("/")[0]
             role = version.split("/")[1]
-            vcfName= f"{sample_name}.{trioName}.joint.GRCh38.small_variants.phased.vcf.gz"
+            vcfName= version.split("/")[2]
             base_folder = f"S3-Storage/{trioName}/{role}/"
         else:
-            print(f"Version did not match: {version} for sample {sample_name}")
-            sys.exit()
+            vcfName = version
+            base_folder = f"S3-Storage/{sample_name}/"
 
 
         # BAM and BAI files are in the same folder


### PR DESCRIPTION
Instead of requiring a version number, which is inflexible and subject to change, specify the name of the vcf on GeneYX to associate the BAM with. 

This will allow more flexibility in associating BAMs to VCFs, because only a single VCF of a given name is allowed on GeneYX. So, if we want multiple versions of a VCF associated with the same BAM, we can simply add the alternate VCF name directly to the list.

For example, if we have two version of a vcf, v1 and v2 associated with the BAM of GM1234:
```
GM1234,V1.vcf.gz
GM1234,V2.vcf.gz
```
We still keep the option of having joint called defined as:
```
GM1234,familyID/proband/V1.vcf.gz
```
Because the path folders are different for families on the S3 Storage.
